### PR TITLE
Enforce the toolchain policy to use C++17.

### DIFF
--- a/winml/CMakeLists.txt
+++ b/winml/CMakeLists.txt
@@ -1,14 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(winml_tracker)
 
-# Default to C++17
+## Compile as at least C++17 for cppwinrt
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 
-## Compile as at least C++17 for cppwinrt
 add_compile_options(/Od)
-add_compile_options(/std:c++latest)
 add_compile_options(/await)
 add_definitions("/D_ENABLE_EXTENDED_ALIGNED_STORAGE")
 add_definitions("/D_USE_MATH_DEFINES")

--- a/winml/CMakeLists.txt
+++ b/winml/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(winml_tracker)
 
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 ## Compile as at least C++17 for cppwinrt
 add_compile_options(/Od)
 add_compile_options(/std:c++latest)

--- a/winml/src/winml_tracker.cpp
+++ b/winml/src/winml_tracker.cpp
@@ -15,6 +15,7 @@
 #include <windows.h>
 
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.AI.MachineLearning.h>
 #include <winrt/Windows.Media.h>
 #include <winrt/Windows.Storage.h>


### PR DESCRIPTION
In the latest Visual Studio 2019 update, the `/std:c++latest` makes the toolchain to target `C++20` , some STL support will be removed and causes the build break. (For example, [`std::unary_negate`](https://en.cppreference.com/w/cpp/utility/functional/unary_negate) in `Eigen` in such case.)

And adding missing header inclusion, which is sensitive to `Windows 10 SDK v10.0.19041.0`.